### PR TITLE
Namespaces, baking in static labels, and small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,18 +97,18 @@ for s in states {
         .expect("valid");
 }
 
-let actual = store.render_into_metrics();
+let actual = store.render_into_metrics(Some("namespace"));
 println!("{}", actual);
 
 let expected = r#"# HELP worker_health worker health
 # TYPE worker_health gauge
-worker_health{name="a",process="simple-metrics"} 1
-worker_health{name="b",process="simple-metrics"} 0
+namespace_worker_health{name="a",process="simple-metrics"} 1
+namespace_worker_health{name="b",process="simple-metrics"} 0
 
 # HELP service_height service height
 # TYPE service_height gauge
-service_height{name="a",process="simple-metrics"} 100
-service_height{name="b",process="simple-metrics"} 200
+namespace_service_height{name="a",process="simple-metrics"} 100
+namespace_service_height{name="b",process="simple-metrics"} 200
 "#;
 
 assert_eq!(actual, expected);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,13 @@ impl Labels {
     pub fn len(&self) -> usize {
         self.inner.len()
     }
+
+    fn render(&self) -> String {
+        self.iter()
+            .map(|(k, v)| format!(r#"{}="{}""#, k, v))
+            .collect::<Vec<String>>()
+            .join(",")
+    }
 }
 
 impl Default for Labels {
@@ -115,15 +122,6 @@ impl<K: Ord + Clone + Into<String>, V: Clone + Into<String>, const N: usize> Fro
 {
     fn from(value: [(K, V); N]) -> Self {
         value.iter().cloned().collect()
-    }
-}
-
-impl RenderIntoMetrics for Labels {
-    fn render_into_metrics(&self) -> String {
-        self.iter()
-            .map(|(k, v)| format!(r#"{}="{}""#, k, v))
-            .collect::<Vec<String>>()
-            .join(",")
     }
 }
 
@@ -425,7 +423,7 @@ impl<K: ToMetricDef> RenderIntoMetrics for MetricStore<K> {
                 metrics.push(format!(
                     "{}{{{}}} {}",
                     metric_def.name,
-                    labels.render_into_metrics(),
+                    labels.render(),
                     s.value.render()
                 ))
             }
@@ -463,7 +461,7 @@ impl<K: ToMetricDef> RenderIntoMetrics for BTreeMap<K, Vec<Sample>> {
                 metrics.push(format!(
                     "{}{{{}}} {}",
                     metric_def.name,
-                    s.labels.render_into_metrics(),
+                    s.labels.render(),
                     s.value.render()
                 ))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,6 +422,10 @@ impl<K: ToMetricDef + Eq + PartialEq + Hash + Ord> MetricStore<K> {
 
         self.static_labels = Labels::new();
     }
+
+    pub fn extend_samples(&mut self, other: &MetricStore<K>) {
+        self.samples.extend(other.clone().samples)
+    }
 }
 
 impl<K: ToMetricDef> RenderIntoMetrics for MetricStore<K> {


### PR DESCRIPTION
Namespaces allow to add a common prefix to all metrics.
I've decided to add it on the very last step, i.e. when metrics are being rendered. This way we don't need to pass the namespace around, and don't need to come up with additional wrappers around `MetricStore`.

Couple of other improvements as well, including
- method to bake the static labels of `MetricStore` into the inner sample set.
- method to extend the samples on the same `MetricStore` type
- + couple of tests and bumped readme