### PR TITLE
Switch metric name matcher from Regex to custom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,3 @@ license = "MIT OR Apache-2.0"
 keywords = ["metrics", "telemetry", "prometheus"]
 
 [dependencies]
-lazy_static = "1.5.0"
-regex = "1.10.5"

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -112,7 +112,7 @@ impl<K: Ord + Clone + Into<String>, V: Clone + Into<String>, const N: usize> Fro
     }
 }
 
-// Somehow the manual ascii check shows higher performans than using
+// Somehow the manual ascii check shows higher performance than using
 // the set of `is_ascii_*()` methods.
 //
 // See https://github.com/qezz/simple-metrics/pull/5 for some details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -514,4 +514,25 @@ namespace_worker_health{name="\"b\"",process="simple-metrics"} 0
 "#;
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn invalid_metric_name() {
+        let starting_with_a_digit = MetricDef::new(
+            "1starting_with_a_digit",
+            "starting with a digit",
+            MetricType::Gauge,
+        );
+        assert!(starting_with_a_digit.is_err());
+
+        let has_spaces = MetricDef::new(
+            "service health",
+            "has spaces in the metric name",
+            MetricType::Gauge,
+        );
+        assert!(has_spaces.is_err());
+
+        let has_weird_chars =
+            MetricDef::new("dobrý_den", "has non ascii characters", MetricType::Gauge);
+        assert!(has_weird_chars.is_err());
+    }
 }


### PR DESCRIPTION
It drops the dependency on Regex, which cuts the build times.