### PR TITLE
Attempt at string interner but it's not a good one

### DIFF
--- a/src/interner.rs
+++ b/src/interner.rs
@@ -1,0 +1,32 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct StringInterner {
+    set: HashSet<Arc<String>>,
+}
+
+impl StringInterner {
+    pub fn new() -> Self {
+        StringInterner {
+            set: HashSet::new(),
+        }
+    }
+
+    pub fn intern(&mut self, s: &str) -> Arc<String> {
+        let val = Arc::new(s.to_string());
+
+        if let Some(existing) = self.set.get(&val) {
+            existing.clone()
+        } else {
+            self.set.insert(val.clone());
+            val
+        }
+    }
+}
+
+impl Default for StringInterner {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod interner;
 pub mod labels;
 pub mod store;
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,14 +1,17 @@
 use std::{collections::BTreeMap, hash::Hash};
 
-use crate::{Error, Labels, MetricValue, RenderIntoMetrics, Sample, ToMetricDef};
+use crate::{
+    interner::StringInterner, Error, Labels, MetricValue, RenderIntoMetrics, Sample, ToMetricDef,
+};
 
 #[derive(Clone, Debug)]
-pub struct MetricStore<K: ToMetricDef> {
-    static_labels: Labels,
+pub struct MetricStore<'a, K: ToMetricDef> {
+    interner: StringInterner,
+    static_labels: &'a Labels<'a>,
     samples: BTreeMap<K, Vec<Sample>>,
 }
 
-impl<K: ToMetricDef + Eq + PartialEq + Hash + Ord> Default for MetricStore<K> {
+impl<'a, K: ToMetricDef + Eq + PartialEq + Hash + Ord> Default for MetricStore<'a, K> {
     fn default() -> Self {
         Self::new()
     }
@@ -17,6 +20,7 @@ impl<K: ToMetricDef + Eq + PartialEq + Hash + Ord> Default for MetricStore<K> {
 impl<K: ToMetricDef + Eq + PartialEq + Hash + Ord> MetricStore<K> {
     pub fn new() -> Self {
         Self {
+            interner: StringInterner::new(),
             static_labels: Labels::new(),
             samples: BTreeMap::new(),
         }


### PR DESCRIPTION
String label values consume a lot of memory when the number of samples grows

That can fixed by having some kind of local cache to reference already allocated strings. That's possible mostly because the labels (and their values) are immutable once added to the `Labels` container