### PR TITLE
Extract LabelsBuilder from Labels

### DIFF
--- a/src/labels.rs
+++ b/src/labels.rs
@@ -2,7 +2,20 @@ use std::collections::{btree_map, BTreeMap};
 
 use crate::labels_builder::LabelsBuilder;
 
-/// Internal representation of sample labels
+/// Opaque representation of sample labels
+///
+/// Use [LabelsBuilder] object to create a new set of labels.
+///
+/// # Examples
+/// ```
+/// use simple_metrics::LabelsBuilder;
+///
+/// let builder = LabelsBuilder::new().with("hello", "world");
+/// let res = builder.build();
+/// let labels = res.unwrap();
+/// assert_eq!(labels.len(), 1);
+///
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Labels {
     pub(crate) inner: BTreeMap<String, String>,
@@ -15,10 +28,25 @@ impl Labels {
         }
     }
 
+    /// Creates a new builder from the existing set of labels.
+    ///
+    /// # Examples
+    /// ```
+    /// use simple_metrics::LabelsBuilder;
+    ///
+    /// let base = LabelsBuilder::new().with("a", "b").build().unwrap();
+    /// let chained = base.builder().with("c", "d").build().unwrap();
+    ///
+    /// let final_keys: Vec<_> = chained.keys().collect();
+    /// assert_eq!(vec!["a", "c"], final_keys);
+    /// ```
     pub fn builder(&self) -> LabelsBuilder {
         LabelsBuilder::from_labels(self)
     }
 
+    /// This method is internal-only.
+    ///
+    /// Use `LabelsBuilder::build` to create a `Labels` object.
     pub(crate) fn from_builder(builder: &LabelsBuilder) -> Self {
         let mut labels = Labels::new();
 

--- a/src/labels.rs
+++ b/src/labels.rs
@@ -1,11 +1,11 @@
 use std::collections::{btree_map, BTreeMap};
 
-use crate::Error;
+use crate::labels_builder::LabelsBuilder;
 
 /// Internal representation of sample labels
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Labels {
-    inner: BTreeMap<String, String>,
+    pub(crate) inner: BTreeMap<String, String>,
 }
 
 impl Labels {
@@ -15,21 +15,18 @@ impl Labels {
         }
     }
 
-    pub fn with<K, V>(mut self, key: K, value: V) -> Self
-    where
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.insert(key, value);
-        self
+    pub fn builder(&self) -> LabelsBuilder {
+        LabelsBuilder::from_labels(self)
     }
 
-    pub fn insert<K, V>(&mut self, key: K, value: V)
-    where
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.inner.insert(key.into(), value.into());
+    pub(crate) fn from_builder(builder: &LabelsBuilder) -> Self {
+        let mut labels = Labels::new();
+
+        for (name, value) in builder.inner.iter() {
+            labels.inner.insert(name.into(), value.into());
+        }
+
+        labels
     }
 
     pub fn iter(&self) -> btree_map::Iter<String, String> {
@@ -77,41 +74,6 @@ impl Extend<(String, String)> for Labels {
     }
 }
 
-impl<T, U> FromIterator<(T, U)> for Labels
-where
-    T: Into<String>,
-    U: Into<String>,
-{
-    fn from_iter<I: IntoIterator<Item = (T, U)>>(iter: I) -> Self {
-        let mut map = BTreeMap::new();
-        for (key, value) in iter {
-            map.insert(key.into(), value.into());
-        }
-        Labels { inner: map }
-    }
-}
-
-impl<'a, T, U> From<&'a [(T, U)]> for Labels
-where
-    T: Into<String> + AsRef<str> + 'a,
-    U: Into<String> + AsRef<str> + 'a,
-{
-    fn from(tuples: &'a [(T, U)]) -> Self {
-        tuples
-            .iter()
-            .map(|(k, v)| (k.as_ref(), v.as_ref()))
-            .collect()
-    }
-}
-
-impl<K: Ord + Clone + Into<String>, V: Clone + Into<String>, const N: usize> From<[(K, V); N]>
-    for Labels
-{
-    fn from(value: [(K, V); N]) -> Self {
-        value.iter().cloned().collect()
-    }
-}
-
 // Somehow the manual ascii check shows higher performance than using
 // the set of `is_ascii_*()` methods.
 //
@@ -137,65 +99,27 @@ pub fn is_valid_label_name(name: &str) -> bool {
     }
 }
 
-pub fn check_labels(labels: &Labels) -> Result<(), Error> {
-    for name in labels.keys() {
-        if !is_valid_label_name(name) {
-            return Err(Error::InvalidLabelName(name.to_string()));
-        }
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::Labels;
+    use crate::{labels_builder::LabelsBuilder, Labels};
 
     #[test]
     fn labels_new() {
         let mut labels_insert = Labels::new();
-        labels_insert.insert("hello", "world");
-        labels_insert.insert("woot", "meh");
+        labels_insert.inner.insert("hello".into(), "world".into());
+        labels_insert.inner.insert("woot".into(), "meh".into());
         assert_eq!(2, labels_insert.len());
 
-        let labels_with = Labels::new().with("hello", "world").with("woot", "meh");
+        let labels_with = LabelsBuilder::new()
+            .with("hello", "world")
+            .with("woot", "meh")
+            .build()
+            .expect("can't build labels");
         assert_eq!(2, labels_with.len());
 
         assert_eq!(labels_insert, labels_with);
 
         let labels_default = Labels::default();
         assert_eq!(0, labels_default.len());
-    }
-
-    #[test]
-    fn labels_with() {
-        let tuples = [("one", "1"), ("two", "2"), ("three", "3")];
-        let labels: Labels = tuples.into_iter().collect();
-        assert_eq!(3, labels.len());
-
-        let new_labels = labels.clone().with("four", "4");
-
-        let tuples2 = [("one", "1"), ("two", "2"), ("three", "3"), ("four", "4")];
-        let labels2: Labels = tuples2.into_iter().collect();
-
-        assert_eq!(new_labels, labels2);
-    }
-
-    #[test]
-    fn labels_from_tuple_list() {
-        let tuples = [("one", "1"), ("two", "2"), ("three", "3")];
-        let labels: Labels = tuples.into_iter().collect();
-        assert_eq!(3, labels.len());
-
-        let labels_from = Labels::from(&tuples[..]);
-        assert_eq!(3, labels_from.len());
-
-        assert_eq!(labels, labels_from);
-
-        let labels_from_2 = Labels::from(&[("one", "1"), ("two", "2"), ("three", "3")][..]);
-        assert_eq!(labels, labels_from_2);
-
-        let labels_from_3 = Labels::from([("one", "1"), ("two", "2"), ("three", "3")]);
-        assert_eq!(labels, labels_from_3);
     }
 }

--- a/src/labels_builder.rs
+++ b/src/labels_builder.rs
@@ -1,0 +1,175 @@
+use std::collections::BTreeMap;
+
+use crate::{labels::is_valid_label_name, Error, Labels};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabelsBuilder {
+    pub(crate) inner: BTreeMap<String, String>,
+}
+
+impl LabelsBuilder {
+    pub fn new() -> Self {
+        Self {
+            inner: BTreeMap::new(),
+        }
+    }
+
+    pub fn from_labels(labels: &Labels) -> Self {
+        Self {
+            inner: labels.inner.clone(),
+        }
+    }
+
+    pub fn with<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.inner.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn insert<K, V>(&mut self, key: K, value: V)
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.inner.insert(key.into(), value.into());
+    }
+
+    pub fn check_labels(&self) -> Result<(), Error> {
+        for (name, _) in self.inner.iter() {
+            if !is_valid_label_name(name) {
+                return Err(Error::InvalidLabelName(name.to_string()));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn build(&self) -> Result<Labels, Error> {
+        self.check_labels()?;
+
+        Ok(Labels::from_builder(self))
+    }
+}
+
+impl Default for LabelsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T, U> FromIterator<(T, U)> for LabelsBuilder
+where
+    T: Into<String>,
+    U: Into<String>,
+{
+    fn from_iter<I: IntoIterator<Item = (T, U)>>(iter: I) -> Self {
+        let mut map = BTreeMap::new();
+        for (key, value) in iter {
+            map.insert(key.into(), value.into());
+        }
+        Self { inner: map }
+    }
+}
+
+impl<'a, T, U> From<&'a [(T, U)]> for LabelsBuilder
+where
+    T: Into<String> + AsRef<str> + 'a,
+    U: Into<String> + AsRef<str> + 'a,
+{
+    fn from(tuples: &'a [(T, U)]) -> Self {
+        tuples
+            .iter()
+            .map(|(k, v)| (k.as_ref(), v.as_ref()))
+            .collect()
+    }
+}
+
+impl<K: Ord + Clone + Into<String>, V: Clone + Into<String>, const N: usize> From<[(K, V); N]>
+    for LabelsBuilder
+{
+    fn from(value: [(K, V); N]) -> Self {
+        value.iter().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Error, Labels};
+
+    use super::LabelsBuilder;
+
+    #[test]
+    fn simple() {
+        let builder = LabelsBuilder::new().with("hello", "world");
+        let labels = builder.build().unwrap();
+
+        let mut builder2 = LabelsBuilder::new();
+        builder2.insert("hello", "world");
+        let labels2 = builder2.build().unwrap();
+
+        let expected = {
+            let mut tmp = Labels::new();
+            tmp.inner.insert("hello".into(), "world".into());
+            tmp
+        };
+
+        assert_eq!(labels, expected);
+        assert_eq!(labels2, expected);
+    }
+
+    #[test]
+    fn labels_with() {
+        let tuples = [("one", "1"), ("two", "2"), ("three", "3")];
+        let builder: LabelsBuilder = tuples.into_iter().collect();
+        let labels = builder.build().unwrap();
+        assert_eq!(3, labels.len());
+
+        let new_labels = labels.clone().builder().with("four", "4").build().unwrap();
+
+        let tuples2 = [("one", "1"), ("two", "2"), ("three", "3"), ("four", "4")];
+        let builder2: LabelsBuilder = tuples2.into_iter().collect();
+        let labels2 = builder2.build().unwrap();
+
+        assert_eq!(new_labels, labels2);
+    }
+
+    #[test]
+    fn labels_from_tuple_list() {
+        let tuples = [("one", "1"), ("two", "2"), ("three", "3")];
+        let builder: LabelsBuilder = tuples.into_iter().collect();
+        let labels = builder.build().unwrap();
+        assert_eq!(3, labels.len());
+
+        let builder_from = LabelsBuilder::from(&tuples[..]);
+        let labels_from = builder_from.build().unwrap();
+        assert_eq!(3, labels_from.len());
+
+        assert_eq!(labels, labels_from);
+
+        let labels_from_2 = LabelsBuilder::from(&[("one", "1"), ("two", "2"), ("three", "3")][..])
+            .build()
+            .unwrap();
+        assert_eq!(labels, labels_from_2);
+
+        let labels_from_3 = LabelsBuilder::from([("one", "1"), ("two", "2"), ("three", "3")])
+            .build()
+            .unwrap();
+        assert_eq!(labels, labels_from_3);
+    }
+
+    #[test]
+    fn invalid_labels() {
+        let builder: LabelsBuilder = LabelsBuilder::new().with("!invalid", "some value");
+        let res = builder.build();
+
+        match res {
+            Ok(_) => panic!("must fail"),
+            Err(e) => {
+                assert_eq!(e, Error::InvalidLabelName("!invalid".to_string()));
+            }
+        }
+    }
+}

--- a/src/labels_builder.rs
+++ b/src/labels_builder.rs
@@ -2,6 +2,31 @@ use std::collections::BTreeMap;
 
 use crate::{labels::is_valid_label_name, Error, Labels};
 
+/// Builder for [Labels] struct.
+///
+/// Label names should match the regex `[a-zA-Z_][a-zA-Z0-9_]*`, that's
+/// why `.build()` returns a `Result`, and it's up to the user how to
+/// handle it.
+///
+/// # Prometheus v3 compatibility note
+///
+/// Prometheus v3 allows metric names and label names to use any UTF-8
+/// characters. **This feature is not currently supported in this
+/// library.** For more details, refer to the official Prometheus
+/// docs: <https://prometheus.io/docs/concepts/data_model/>
+///
+///
+/// # Examples
+/// ```
+/// use simple_metrics::LabelsBuilder;
+///
+/// let builder_result = LabelsBuilder::new()
+///     .with("hello", "world")
+///     .with("simple", "metrics")
+///     .build();
+/// let _ = builder_result.expect("label names are invalid");
+///
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LabelsBuilder {
     pub(crate) inner: BTreeMap<String, String>,


### PR DESCRIPTION
Having `LabelsBuilder` outside of `Labels` allows to aggregate the
labels separately, and then build them only once.

That allows to get rid of `Result`s being returned from
`store.add_value()` and `Sample::new()` functions.

It also comes with implication that all labels in `Labels` are already
checked and are valid. Because of this, it's not allowed to add labels
directly to a `Labels` object anymore.